### PR TITLE
docs(sitemap): Add baseURL to sitemap plugin config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,6 +20,10 @@ package = "@netlify/plugin-sitemap"
 
   [plugins.inputs]
   buildDir = "public"
+  # set baseURL because we aren't configuring a custom domain in Netlify
+  # Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like http://example.com/en/ will results in http://example.com/
+  # https://github.com/netlify-labs/netlify-plugin-sitemap
+  baseUrl = "https://developer.armory.io"
   
   # append missing trailing slash to prettyURL
   trailingSlash = true


### PR DESCRIPTION
Configure baseUrl in sitemap plugin


Partial Jira: [DOC-726]

Some of the sitemap output with `baseUrl` configured:
```
<url>
<loc>https://developer.armory.io/docs/concepts/</loc>
<lastmod>2023-06-09T19:58:54Z</lastmod>
<changefreq>daily</changefreq>
<priority>0.5</priority>
</url>
<url>
<loc>https://developer.armory.io/docs/plugin-spinnaker/</loc>
<lastmod>2023-06-09T19:58:54Z</lastmod>
<changefreq>daily</changefreq>
<priority>0.5</priority>
</url>
<url>
<loc>https://developer.armory.io/docs/reference/</loc>
<lastmod>2023-06-09T19:58:54Z</lastmod>
<changefreq>daily</changefreq>
<priority>0.5</priority>
</url>
<url>
<loc>https://developer.armory.io/docs/release-notes/</loc>
<lastmod>2023-06-09T19:58:54Z</lastmod>
<changefreq>daily</changefreq>
<priority>0.5</priority>
</url>
<url>
<loc>https://developer.armory.io/docs/setup/</loc>
<lastmod>2023-06-09T19:58:54Z</lastmod>
<changefreq>daily</changefreq>
<priority>0.5</priority>
</url>
<url>
<loc>https://developer.armory.io/docs/tasks/</loc>
<lastmod>2023-06-09T19:58:54Z</lastmod>
<changefreq>daily</changefreq>
<priority>0.5</priority>
</url>
```


[DOC-726]: https://armory.atlassian.net/browse/DOC-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ