### PR TITLE
docs(strategy): Updated text for canary strategy 

### DIFF
--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -36,164 +36,148 @@ Before configuring a canary strategy in your [deployment]({{< ref "deployment/ov
   
   Your [Kubernetes Deployment object](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) describes the desired state for your application Pods and ReplicaSets. 
 
+## Define a canary deployment strategy
 
-## Add your metrics provider
+1. [Declare your strategy](#declare-your-strategy).
+1. [Add your strategy to your deployment target](#add-your-strategy-to-your-deployment-target).
 
-Armory CD-as-a-Service can run queries against metrics providers that you add. The results are examined as part of canary analysis steps in the deploy file.
 
-1. In the **Configuration UI**, go to [**Canary Analysis > Integrations**](https://console.cloud.armory.io/configuration/metric-source-integrations/).
-2. Select **New Integration**.
+### Declare your strategy
 
-   The examples in this guide use Prometheus as the metrics provider.
+You define your blue/green strategy in the root-level `strategies` section of your CD-as-a-Service deployment config file.  The strategy has two required fields:
 
-3. Complete the wizard:
 
-   The parameters you need to provide depend on the metrics provider you choose. For more information, see the {{< linkWithTitle "canary-analysis/integrate-metrics-provider.md" >}} guide.
+```yaml
+strategies:
+  <name-for-your-canary-strategy>:
+    canary:
+      steps:
+        - setWeight: 10
+        - pause:
+            untilApproved: true
+        - setWeight: 20
+        - pause:
+            untilApproved: true
+        - setWeight: 100
+```
+* `steps`: Define a list of steps that constitue your canary strategy. CD-as-a-Service excutes steps sequentially, waiting for the previous step to finish before starting the next step. This enables you to configure monitoring during canary using analysis or webhooks. 
 
-   The following fields are for a Prometheus integration:
+* `setWeight`: Define how much traffic should get directed to the new version of your application. CD-as-a-Service will manipulated the relevant resources to send the traffic to your new version. 
 
-   - **Type**: (Required) Your metrics provider. This example uses Prometheus. The form options change based on your provider.
-   - **Name**: (Required) A descriptive name for your metrics provider, such as the environment it monitors. You use this name in places such as your deploy file when you want to configure canary analysis as part of your deployment strategy.
-   - **Base URL**: (Required) The base URL for your Prometheus instance. If Prometheus runs in the same cluster as the RNA and is exposed using HTTP on port 9090 through a service named `prometheus` in the namespace `prometheus`, then use `http://prometheus.prometheus:9090`. (This can be a private DNS only if the RNA is installed in the same cluster as the Prometheus instance.)
-   - **Remote Network Agent**: (Optional) The RNA that is installed in the Prometheus cluster if the cluster is not publicly accessible. Select the identifier for the RNA from the dropdown.
-   - **Authentication Type**: (Required) Select **None**, **Username/Password**, or **Bearer Token**.
+### Add your strategy to your deployment target
 
-      - If you selected **Username/Password**: Fill in the username for accessing Prometheus and select the password secret.
-      - If you selected **Bearer Token**: Select the token secret from the drop-down list.
+After you configure your strategy, you need to add it to your deployment targets:
 
-## Perform a retrospective analysis
-
-Retrospective analysis is the starting point to creating queries so that you can perform canary analysis on your deployments. The UI gives you a structured way to create a query and test it against previous deployments. When ready, you can export it so that you can add the query to your deploy file easily.
-
-1. In the **Configuration UI**, go to [**Canary Analysis > Retrospective Analysis**](https://console.cloud.armory.io/configuration/metric-source-integrations/).
-2. Select the metric provider you just configured.
-3. Select a time range that includes when you deployed your app.
-4. Add a **Query Template**. Use the following example:
-
-   - **Name**: avgCPUUsage
-   - **Upper Limit**: The upper limit for the query. If the results exceed this value, the deployment is considered to be a failure. Set this to `10000`.
-   - **Lower Limit**: The lower limit for the query. If the results fall below this value, the deployment is considered to be a failure. Set this to `0`.
-   - **Query Template**:
-
-      ```
-      avg(avg_over_time(container_cpu_system_seconds_total{job="kubelet"}[{{armory.promQlStepInterval}}]) * on (pod) group_left (annotation_app)
-      sum(kube_pod_annotations{job="kube-state-metrics",annotation_deploy_armory_io_replica_set_name="{{armory.replicaSetName}}"}) by (annotation_app, pod)) by (annotation_app)
-      ```
-
-      - **The query must return a single result**. Automated canary analysis does not support queries that return multiple values. See [Query template requirements]({{< ref "canary-analysis-query#query-template-requirements" >}}) for restrictions and provider examples.
-      - The query contains variables that are automatically injected during canary analysis, but you must manually provide some of them during retrospective analysis.
-        - Time related variables like `armory.promqlStepInterval` are automatically substituted by Armory CD-as-a-Service. For a full list, see the {{< linkWithTitle "reference/context-variables.md" >}} guide.
-        - `armory.replicaSetName` needs to be set to the name of the ReplicaSet that Armory CD-as-a-Service created for this app version. It's used to differentiate between the current and next version of the app. Do this in the next step where you add key/value pairs.
-
-5. Add **Key Value (KV) Pair** for the **Context**. The key value pairs for your  For the sample query, you need to add the following key value Pair:
-
-  - **Key**: `replicaSetName`
-
-    **Value**: The name of the ReplicaSet that was created when you deployed the app in *Get Started with the CLI to Deploy Apps* guide.
-
-6. Run the analysis. If the results fall within the upper and lower limits you set, the deployment is considered a success.
-
-### Export and add a query to your deploy file
-
-The Retrospective Analysis can take the query you provide and generate the YAML equivalent that you can use it in your deploy file.
-
-1. From the analysis screen, select **Go back to Analysis Configuration**.
-2. Click **Export Queries for Armory Deployments**. This creates the YAML block for the `analysis` portion of a deploy file.
-3. Insert the YAML block into your deploy file at the bottom. For example:
-
-   ```yaml
-   analysis:
-     queries:
-      - name: avgCPUUsage
-        upperLimit: 10000
-        lowerLimit: 0
-        queryTemplate: >-
-          avg (avg_over_time(container_cpu_system_seconds_total{job="kubelet"}[{{armory.promQlStepInterval}}]) * on (pod)  group_left (annotation_app)
-          sum(kube_pod_annotations{job="kube-state-metrics",annotation_deploy_armory_io_replica_set_name="{{armory.replicaSetName}}"})
-          by (annotation_app, pod)) by (annotation_app)
-   ```
-
-For a detailed explanation of these fields, see the [Deployment File Reference]({{< ref "reference/deployment/config-file/analysis.md" >}})
-
-The `avgCPUUsage` query is now available for you to use in the `steps` block of your deploy file to perform canary analysis.
-
-## Add canary analysis to your deployment
-
-Armory CD-as-a-Service supports manual and automated canary analysis. Manual canary analysis allows you to review the canary results until you have confidence that your queries are making good decisions around service health.
-
-Adding canary analysis to your deployment involves updating your deploy file to include the following:
-
-- An `analysis` block that describes what queries to use and how they are run. The YAML for the queries is what you can export from the UI. You did this in [Export and add a query to your deploy file](#export-and-add-a-query-to-your-deploy-file).
-- Steps in your `strategy` block that perform canary analysis and define how it behaves.
-
-1. In your deploy file, go to the `strategies` section.
-2. Create a new strategy named `canary-deploy-strat` like the following:
-
-   ```yaml
-   strategies:
-    canary-deploy-strat
-      canary:
-        steps:
-          - setWeight:
-              weight: 50
-          - analysis:
-              interval: 10
-              units: seconds
-              numberOfJudgmentRuns: 3
-              rollBackMode: manual
-              rollForwardMode: manual
-              queries: # The queries to run
-                - avgCPUUsage
-          - setWeight:
-              weight: 75
-          - analysis:
-              interval: 10
-              units: seconds
-              numberOfJudgmentRuns: 3
-              rollBackMode: manual
-              rollForwardMode: manual
-              queries:
-                - avgCPUUsage
-   ```
-
-   For a detailed explanation of these fields, see the [Deployment File Reference]({{< ref "reference/deployment/config-file//strategies" >}})
-
-   This strategy deploys the app to 50% of the cluster and then performs a canary analysis with the following characteristics:
-
-   - The interval for each run of the query is 10 seconds.
-   - The number of runs of the query is 3.
-   - Rolling a deployment back or forward is done manually using the Deployments UI.
-   - It uses the query `containerCPUSeconds`.
-
-   The strategy then deploys the app to 75% of the cluster and then performs a canary analysis. After the roll forward is approved, Armory CD-as-a-Service deploys the app to 100% of the cluster.
-
-3. Change the value of  `targets.<targetName>.strategy` for one or more of your deployment targets to `canary-deploy-strat`.
-
-   ```yaml
-   ...
-   targets:
-     <targetName>:
-       account: <agentIdentifier>
-       namespace: <namespace>
-       strategy: canary-deploy-strat
+```yaml
+targets:
+  staging:  
     ...
-    ```
-4. Save the file
-
-## Redeploy your app
-
-Make a change to your app, such as the number of replicas, and redeploy it with the CLI:
-
-```bash
-armory deploy start  -f <your-deploy-file>.yaml
+    strategy: <name-for-your-canary-strategy>
+  prod:  
+    ...
+    strategy: <name-for-your-canary-strategy>
 ```
 
-Monitor the progress and approve the canary steps in the UI.
+You can define different canary strategies for different deployment targets.
 
-### Go from manual to automated
+## Example deployment config file
 
-Once you have confidence in your queries, switching from manual approvals of canary steps to automatic approvals involves updating the `analysis` steps in your strategy. You can either comment out the `rollBackMode` and `rollForwardMode` fields or set them to `automatic`. Subsequent deployments using the updated deploy file will progress the deployment automatically if the canary analysis steps pass.
+In this basic example, you deploy an app called "sample-app" to two deployment targets.
 
+```yaml
+version: v1
+kind: kubernetes
+application: sample-app
+targets:
+  staging:  
+    account: staging-cluster
+    namespace: staging-ns
+    strategy: sample-app-canary
+  prod:  
+    account: prod-cluster
+    namespace: prod-ns
+    strategy: sample-app-canary
+manifests:
+  - path: manifests/<your-app>.yaml # the path to and name of your app manifest
+strategies:
+  sample-app-canary:
+    canary:
+      steps:
+        - setWeight: 10
+        - pause:
+            untilApproved: true
+        - setWeight: 20
+        - pause:
+            untilApproved: true
+        - setWeight: 100
+```
+
+<details><summary>Show me the app manifest</summary>
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-app
+  annotations: 
+    "app": "sample-app"
+spec:
+  revisionHistoryLimit: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: sample-app
+  template:
+    metadata:
+      labels:
+        app: sample-app
+      annotations: 
+        "app": "sample-app"
+    spec:
+      containers:
+      - image:  demoimages/bluegreen:v3 #v5, v4, v3
+        imagePullPolicy: Always
+        name: sample-app
+        resources:
+          limits:
+            cpu: "100m" # this is to ensure the above busy wait cannot DOS a low CPU cluster.
+            memory: "70Mi"
+          requests:
+            cpu: "10m" # this is to ensure the above busy wait cannot DOS a low CPU cluster.
+            memory: "70Mi"
+        #ports:
+        #  - containerPort: 8086
+      restartPolicy: Always
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-app-svc
+  labels:
+    app: sample-app
+  annotations:
+    linkerd.io/inject: enabled
+spec:
+  selector:
+    app: sample-app
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+      protocol: TCP
+```
+</details>
+
+## Using canary strategies with service mesh
+
+Service meshes allow setting up accurate traffic split between the new version and the old version of your application.
+ 
 ## {{% heading "nextSteps" %}}
 
 * {{< linkWithTitle "canary-analysis/create-canary-queries.md" >}}

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -10,7 +10,7 @@ tags: ["Kubernetes", "Deploy Strategy", "Canary"]
 
 ## What a canary strategy does
 
-A canary strategy involves shifting a small percentage of traffic to the new version of your application. You specify conditions before gradually increasing the traffic percentage to the new version. Service meshes like Istio and Linkerd enable finer-grained traffic shaping patterns compared to what is available natively. See the [Strategies Overview]({{< ref "deployment/strategies/overview" >}}) for details on the advantages of using a canary deployment strategy.
+A canary strategy involves shifting a small percentage of traffic to the new version of your application. You specify conditions and then gradually increase the traffic percentage to the new version. Service meshes like Istio and Linkerd enable finer-grained traffic shaping patterns compared to what is available natively. See the [Strategies Overview]({{< ref "deployment/strategies/overview" >}}) for details on the advantages of using a canary deployment strategy.
 
 ## How CD-as-a-Service implements canary
 With CD-as-a-Service, users can configure their canary deployment strategy as they desire. Users can define a list of steps that are executed sequentially when executing the strategy. When executing the strategy, CD-as-a-Service creates a new ReplicaSet  for the new version of the application and manipulates the ReplicaSet  object and other resources to shape traffic. 
@@ -19,12 +19,12 @@ CD-as-a-Service uses `setWeight` step type to shape the traffic to the new versi
 ### Canary strategy without service mesh
 When using a canary strategy without a service mesh, CD-as-a-Service performs the following steps:
 1. CD-as-a-Service evaluates the setWeight step to determine the traffic split between the new version and the old version.
-1. CD-as-a-Service manipulates ReplicaSet  objects of the new version and the old version to achieve the desired traffic split by changing the number of pods in each ReplicaSet .
+1. CD-as-a-Service manipulates ReplicaSet  objects of the new version and the old version to achieve the desired traffic split by changing the number of pods in each ReplicaSet.
 
 
 ### Canary strategy with service mesh
 When using a canary strategy with a service mesh like Istio or Linkerd, CD-as-a-Service performs the following steps:
-1. CD-as-a-Service creates the ReplicaSet  for the new version of the application without changing the `replicaCount` specified in the Kubernetes deployment object. 
+1. CD-as-a-Service creates the ReplicaSet for the new version of the application without changing the `replicaCount` specified in the Kubernetes deployment object. 
 1. CD-as-a-Service evaluates the `setWeight` step to determine the traffic split between the new version and the old version.
 1. CD-as-a-Service manipulates the relevant objects that are involved in shaping the traffic for the service mesh. 
 

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -13,44 +13,28 @@ tags: ["Kubernetes", "Deploy Strategy", "Canary"]
 A canary strategy involves shifting a small percentage of traffic to the new version of your application. You specify conditions before gradually increasing the traffic percentage to the new version. Service meshes like Istio and Linkerd enable finer-grained traffic shaping patterns compared to what is available natively. See the [Strategies Overview]({{< ref "deployment/strategies/overview" >}}) for details on the advantages of using a canary deployment strategy.
 
 ## How CD-as-a-Service implements canary
-With CD-as-a-Service, users can configure their canary deployment strategy as they desire. Users can define a list of steps that are executed sequentially when executing the strategy. When executing the strategy, CD-as-a-Service creates a new Replicaset for the new version of the application and manipulates the Replicaset object and other resources to shape traffic. 
+With CD-as-a-Service, users can configure their canary deployment strategy as they desire. Users can define a list of steps that are executed sequentially when executing the strategy. When executing the strategy, CD-as-a-Service creates a new ReplicaSet  for the new version of the application and manipulates the ReplicaSet  object and other resources to shape traffic. 
 CD-as-a-Service uses `setWeight` step type to shape the traffic to the new version. Traffic is shaped differently depending on if you are using service mesh or not. 
 
 ### Canary strategy without service mesh
 When using a canary strategy without a service mesh, CD-as-a-Service performs the following steps:
 1. CD-as-a-Service evaluates the setWeight step to determine the traffic split between the new version and the old version.
-1. CD-as-a-Service manipulates Replicaset objects of the new version and the old version to achieve the desired traffic split by changing the number of pods in each Replicaset.
+1. CD-as-a-Service manipulates ReplicaSet  objects of the new version and the old version to achieve the desired traffic split by changing the number of pods in each ReplicaSet .
 
 
 ### Canary strategy with service mesh
 When using a canary strategy with a service mesh like Istio or LinkerD, CD-as-a-Service performs the following steps:
-1. CD-as-a-Service creates the Replicaset for the new version of the application without changing the `replicaCount` specified in the deployment object. 
+1. CD-as-a-Service creates the ReplicaSet  for the new version of the application without changing the `replicaCount` specified in the Kubernetes deployment object. 
 1. CD-as-a-Service evaluates the `setWeight` step to determine the traffic split between the new version and the old version.
 1. CD-as-a-Service manipulates the relevant objects that are involved in shaping the traffic for the service mesh. 
 
 ## {{% heading "prereq" %}}
 
-You have completed the following guides:
+Before configuring a canary strategy in your [deployment]({{< ref "deployment/overview" >}}), you should have the following:
 
-1. {{< linkWithTitle "get-started/quickstart.md" >}}
-1. {{< linkWithTitle "get-started/deploy-your-app.md" >}}
-
-You need the following to work through this guide:
-
-- Access to a Kubernetes cluster where you can install the Remote Network Agent (RNA). This cluster acts as the deployment target for the sample app. You can reuse the clusters from the previous quick starts if you want. Or stand up new ones.
-- A Prometheus instance set up to monitor your Kubernetes clusters. Keep the following in mind:
-
-  - Armory recommends your Prometheus instance uses the following settings: `"prometheus.io/scrape": "true"` (on by default) and `kube-state-metrics.metricAnnotationsAllowList[0]=pods=[*]` (collect annotations). These  flags instruct Prometheus to collect all Kubernetes annotations, which allow you to reference the annotations that Armory CD-as-a-Service injects as part of your query.
-
-   If you install Prometheus with Helm, this example command includes the required flag:
-
-   ```yaml
-   helm upgrade --install prometheus prometheus-community/kube-prometheus-stack --set 'kube-state-metrics.metricAnnotationsAllowList[0]=pods=[*]'
-   ```
-
-  - It is either accessible by the public internet or you have installed the Remote Network Agent (RNA) in the same cluster.
-
-   For information about how to install Prometheus, see the the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
+* Kubernetes Deployment object
+  
+  Your [Kubernetes Deployment object](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) describes the desired state for your application Pods and ReplicaSets. 
 
 
 ## Add your metrics provider

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -176,9 +176,15 @@ spec:
 
 ## Using canary strategies with service mesh
 
-Service meshes allow setting up accurate traffic split between the new version and the old version of your application.
+Service meshes allow setting up accurate traffic split between the new version and the old version of your application. If you are using a service mesh you need to add a `trafficManagement` block to your deployment config.
+
+```yaml
+trafficManagement:
+  - istio:
+      ...
+```
  
 ## {{% heading "nextSteps" %}}
 
-* {{< linkWithTitle "canary-analysis/create-canary-queries.md" >}}
-* {{< linkWithTitle "reference/canary-analysis-query.md" >}}
+* [Using Service Mesh for canary]({{< ref "traffic-management/overview.md" >}})
+* [Configure your metrics provider to use canary analysis]({{< ref "canary-analysis/overview.md" >}})

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -8,13 +8,9 @@ categories: ["Deployment", "Guides"]
 tags: ["Kubernetes", "Deploy Strategy", "Canary"]
 ---
 
-## Overview of canary deployments
+## What a canary strategy does
 
-Armory CD-as-a-Service supports performing canary deployments. The canary deployment strategy deploys an app progressively to your cluster based on a set of steps that you configure. You set weights (percentage thresholds) for how the deployment should progress and a pause after each weight is met. Armory CD-as-a-Service works through these steps until your app is fully deployed. For example, you can deploy the new version of your app to 25% of your target cluster and then wait for a manual judgement or a configurable amount of time. This pause gives you time to assess the impact of your changes. From there, either continue the deployment to the next weight you set or roll back the deployment if you notice an issue.
-
-Performing retrospective analysis on a deployment is a great way to understand how your app is performing over a predefined time period. It is the first step to enabling automatic canary analysis where you create queries that control how canary deployments react based on metrics you consider important.
-
-The examples in this guide use Prometheus as the metrics provider.
+A canary strategy involves shifting a small percentage of traffic to the new version of your application. You specify conditions before gradually increasing the traffic percentage to the new version. Service meshes like Istio and Linkerd enable finer-grained traffic shaping patterns compared to what is available natively. See the [Strategies Overview]({{< ref "deployment/strategies/overview" >}}) for details on the advantages of using a canary deployment strategy.
 
 ## {{% heading "prereq" %}}
 

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -13,8 +13,7 @@ tags: ["Kubernetes", "Deploy Strategy", "Canary"]
 A canary strategy involves shifting a small percentage of traffic to the new version of your application. You specify conditions and then gradually increase the traffic percentage to the new version. Service meshes like Istio and Linkerd enable finer-grained traffic shaping patterns compared to what is available natively. See the [Strategies Overview]({{< ref "deployment/strategies/overview" >}}) for details on the advantages of using a canary deployment strategy.
 
 ## How CD-as-a-Service implements canary
-With CD-as-a-Service, users can configure their canary deployment strategy as they desire. Users can define a list of steps that are executed sequentially when executing the strategy. When executing the strategy, CD-as-a-Service creates a new ReplicaSet  for the new version of the application and manipulates the ReplicaSet  object and other resources to shape traffic. 
-CD-as-a-Service uses `setWeight` step type to shape the traffic to the new version. Traffic is shaped differently depending on if you are using service mesh or not. 
+With CD-as-a-Service, users can configure their canary deployment strategy however they want. Users define a list of steps that are executed sequentially when the strategy is executed. When the strategy is executed, CD-as-a-Service creates a new ReplicaSet for the new version of the application and manipulates the ReplicaSet object and other resources to shape traffic. CD-as-a-Service uses the `setWeight` step type to shape traffic to the new version. Traffic is shaped differently depending on whether or not you are using service mesh.
 
 ### Canary strategy without service mesh
 When using a canary strategy without a service mesh, CD-as-a-Service performs the following steps:
@@ -23,7 +22,7 @@ When using a canary strategy without a service mesh, CD-as-a-Service performs th
 
 
 ### Canary strategy with service mesh
-When using a canary strategy with a service mesh like Istio or Linkerd, CD-as-a-Service performs the following steps:
+When using a canary strategy with a service mesh such as Istio or Linkerd, CD-as-a-Service performs the following steps:
 1. CD-as-a-Service creates the ReplicaSet for the new version of the application without changing the `replicaCount` specified in the Kubernetes deployment object. 
 1. CD-as-a-Service evaluates the `setWeight` step to determine the traffic split between the new version and the old version.
 1. CD-as-a-Service manipulates the relevant objects that are involved in shaping the traffic for the service mesh. 

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -12,6 +12,9 @@ tags: ["Kubernetes", "Deploy Strategy", "Canary"]
 
 A canary strategy involves shifting a small percentage of traffic to the new version of your application. You specify conditions before gradually increasing the traffic percentage to the new version. Service meshes like Istio and Linkerd enable finer-grained traffic shaping patterns compared to what is available natively. See the [Strategies Overview]({{< ref "deployment/strategies/overview" >}}) for details on the advantages of using a canary deployment strategy.
 
+## How CD-as-a-Service implements canary
+With CD-as-a-Service, users can configure their canary deployment strategy as they desire. Users can define a list of steps that are executed sequentially when executing the strategy.
+CD-as-a-Service uses `setWeight` step type to shape the traffic to the new version. 
 ## {{% heading "prereq" %}}
 
 You have completed the following guides:

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -23,7 +23,7 @@ When using a canary strategy without a service mesh, CD-as-a-Service performs th
 
 
 ### Canary strategy with service mesh
-When using a canary strategy with a service mesh like Istio or LinkerD, CD-as-a-Service performs the following steps:
+When using a canary strategy with a service mesh like Istio or Linkerd, CD-as-a-Service performs the following steps:
 1. CD-as-a-Service creates the ReplicaSet  for the new version of the application without changing the `replicaCount` specified in the Kubernetes deployment object. 
 1. CD-as-a-Service evaluates the `setWeight` step to determine the traffic split between the new version and the old version.
 1. CD-as-a-Service manipulates the relevant objects that are involved in shaping the traffic for the service mesh. 
@@ -60,7 +60,7 @@ strategies:
             untilApproved: true
         - setWeight: 100
 ```
-* `steps`: Define a list of steps that constitue your canary strategy. CD-as-a-Service executes steps sequentially, waiting for each step to finish before starting the next step. This enables you to configure monitoring during canary using analysis or webhooks. 
+* `steps`: Define a list of steps that constitute your canary strategy. CD-as-a-Service executes steps sequentially, waiting for each step to finish before starting the next step. This enables you to configure monitoring during canary using analysis or webhooks. 
 
 * `setWeight`: Define how much traffic should get directed to the new version of your application. CD-as-a-Service will manipulate the relevant resources to gradually increase the traffic to the new version. 
 
@@ -161,8 +161,6 @@ metadata:
   name: sample-app-svc
   labels:
     app: sample-app
-  annotations:
-    linkerd.io/inject: enabled
 spec:
   selector:
     app: sample-app

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -176,15 +176,17 @@ spec:
 
 ## Using canary strategies with service mesh
 
-Service meshes allow setting up accurate traffic split between the new version and the old version of your application. If you are using a service mesh you need to add a `trafficManagement` block to your deployment config.
+Service meshes allow setting up accurate traffic split between the new version and the old version of your application. If you are using a service mesh you need to add a `trafficManagement` block to your deployment config. 
 
 ```yaml
 trafficManagement:
   - istio:
       ...
 ```
- 
+For more info on using service mes, see:
+* [Using service mesh for canary]({{< ref "traffic-management/overview.md" >}})
+
 ## {{% heading "nextSteps" %}}
 
-* [Using Service Mesh for canary]({{< ref "traffic-management/overview.md" >}})
 * [Configure your metrics provider to use canary analysis]({{< ref "canary-analysis/overview.md" >}})
+* See the [Deployment File Reference]({{< ref "reference/deployment/config-file/strategies#canary-fields" >}}) for detailed field explanations.

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -62,7 +62,7 @@ strategies:
 ```
 * `steps`: Define a list of steps that constitue your canary strategy. CD-as-a-Service executes steps sequentially, waiting for each step to finish before starting the next step. This enables you to configure monitoring during canary using analysis or webhooks. 
 
-* `setWeight`: Define how much traffic should get directed to the new version of your application. CD-as-a-Service will manipulate the relevant resources to send the traffic to your new version. 
+* `setWeight`: Define how much traffic should get directed to the new version of your application. CD-as-a-Service will manipulate the relevant resources to gradually increase the traffic to the new version. 
 
 ### Add your strategy to your deployment target
 

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -60,9 +60,9 @@ strategies:
             untilApproved: true
         - setWeight: 100
 ```
-* `steps`: Define a list of steps that constitue your canary strategy. CD-as-a-Service excutes steps sequentially, waiting for the previous step to finish before starting the next step. This enables you to configure monitoring during canary using analysis or webhooks. 
+* `steps`: Define a list of steps that constitue your canary strategy. CD-as-a-Service executes steps sequentially, waiting for each step to finish before starting the next step. This enables you to configure monitoring during canary using analysis or webhooks. 
 
-* `setWeight`: Define how much traffic should get directed to the new version of your application. CD-as-a-Service will manipulated the relevant resources to send the traffic to your new version. 
+* `setWeight`: Define how much traffic should get directed to the new version of your application. CD-as-a-Service will manipulate the relevant resources to send the traffic to your new version. 
 
 ### Add your strategy to your deployment target
 

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -13,8 +13,21 @@ tags: ["Kubernetes", "Deploy Strategy", "Canary"]
 A canary strategy involves shifting a small percentage of traffic to the new version of your application. You specify conditions before gradually increasing the traffic percentage to the new version. Service meshes like Istio and Linkerd enable finer-grained traffic shaping patterns compared to what is available natively. See the [Strategies Overview]({{< ref "deployment/strategies/overview" >}}) for details on the advantages of using a canary deployment strategy.
 
 ## How CD-as-a-Service implements canary
-With CD-as-a-Service, users can configure their canary deployment strategy as they desire. Users can define a list of steps that are executed sequentially when executing the strategy.
-CD-as-a-Service uses `setWeight` step type to shape the traffic to the new version. 
+With CD-as-a-Service, users can configure their canary deployment strategy as they desire. Users can define a list of steps that are executed sequentially when executing the strategy. When executing the strategy, CD-as-a-Service creates a new Replicaset for the new version of the application and manipulates the Replicaset object and other resources to shape traffic. 
+CD-as-a-Service uses `setWeight` step type to shape the traffic to the new version. Traffic is shaped differently depending on if you are using service mesh or not. 
+
+### Canary strategy without service mesh
+When using a canary strategy without a service mesh, CD-as-a-Service performs the following steps:
+1. CD-as-a-Service evaluates the setWeight step to determine the traffic split between the new version and the old version.
+1. CD-as-a-Service manipulates Replicaset objects of the new version and the old version to achieve the desired traffic split by changing the number of pods in each Replicaset.
+
+
+### Canary strategy with service mesh
+When using a canary strategy with a service mesh like Istio or LinkerD, CD-as-a-Service performs the following steps:
+1. CD-as-a-Service creates the Replicaset for the new version of the application without changing the `replicaCount` specified in the deployment object. 
+1. CD-as-a-Service evaluates the `setWeight` step to determine the traffic split between the new version and the old version.
+1. CD-as-a-Service manipulates the relevant objects that are involved in shaping the traffic for the service mesh. 
+
 ## {{% heading "prereq" %}}
 
 You have completed the following guides:

--- a/content/en/deployment/strategies/canary.md
+++ b/content/en/deployment/strategies/canary.md
@@ -35,6 +35,8 @@ Before configuring a canary strategy in your [deployment]({{< ref "deployment/ov
   
   Your [Kubernetes Deployment object](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment) describes the desired state for your application Pods and ReplicaSets. 
 
+  >If you do not have a Kubernetes deployment object being deployed to a target, CD-as-a-Service will ignore the strategy and deploy all the manifests destined for the target.
+
 ## Define a canary deployment strategy
 
 1. [Declare your strategy](#declare-your-strategy).

--- a/content/en/tutorials/retrospective-analysis.md
+++ b/content/en/tutorials/retrospective-analysis.md
@@ -1,0 +1,206 @@
+---
+title: Canary Deployment With Retrospective Analysis Tutorial
+linkTitle: Retrospective Analysis
+description: >
+  Learn how to configure a canary deployment strategy that uses retrospective analysis. Integrate your metrics provider, create a retrospective analysis query, and add canary analysis as a deployment constraint. Deploy your app to your Kubernetes cluster using Armory CD-as-a-Service.
+categories: ["Deployment", "Tutorials"]
+tags: ["Deploy Strategy", "Retrospective Analysis", "Kubernetes"]
+draft: true
+---
+
+@TODO turn this into a proper tutorial, like the blue/green one
+
+## Overview of canary deployments
+
+Armory CD-as-a-Service supports performing canary deployments. The canary deployment strategy deploys an app progressively to your cluster based on a set of steps that you configure. You set weights (percentage thresholds) for how the deployment should progress and a pause after each weight is met. Armory CD-as-a-Service works through these steps until your app is fully deployed. For example, you can deploy the new version of your app to 25% of your target cluster and then wait for a manual judgement or a configurable amount of time. This pause gives you time to assess the impact of your changes. From there, either continue the deployment to the next weight you set or roll back the deployment if you notice an issue.
+
+Performing retrospective analysis on a deployment is a great way to understand how your app is performing over a predefined time period. It is the first step to enabling automatic canary analysis where you create queries that control how canary deployments react based on metrics you consider important.
+
+The examples in this guide use Prometheus as the metrics provider.
+
+## {{% heading "prereq" %}}
+
+You have completed the following guides:
+
+1. {{< linkWithTitle "get-started/quickstart.md" >}}
+1. {{< linkWithTitle "get-started/deploy-your-app.md" >}}
+
+You need the following to work through this guide:
+
+- Access to a Kubernetes cluster where you can install the Remote Network Agent (RNA). This cluster acts as the deployment target for the sample app. You can reuse the clusters from the previous quick starts if you want. Or stand up new ones.
+- A Prometheus instance set up to monitor your Kubernetes clusters. Keep the following in mind:
+
+  - Armory recommends your Prometheus instance uses the following settings: `"prometheus.io/scrape": "true"` (on by default) and `kube-state-metrics.metricAnnotationsAllowList[0]=pods=[*]` (collect annotations). These  flags instruct Prometheus to collect all Kubernetes annotations, which allow you to reference the annotations that Armory CD-as-a-Service injects as part of your query.
+
+   If you install Prometheus with Helm, this example command includes the required flag:
+
+   ```yaml
+   helm upgrade --install prometheus prometheus-community/kube-prometheus-stack --set 'kube-state-metrics.metricAnnotationsAllowList[0]=pods=[*]'
+   ```
+
+  - It is either accessible by the public internet or you have installed the Remote Network Agent (RNA) in the same cluster.
+
+   For information about how to install Prometheus, see the the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
+
+
+## Add your metrics provider
+
+Armory CD-as-a-Service can run queries against metrics providers that you add. The results are examined as part of canary analysis steps in the deploy file.
+
+1. In the **Configuration UI**, go to [**Canary Analysis > Integrations**](https://console.cloud.armory.io/configuration/metric-source-integrations/).
+2. Select **New Integration**.
+
+   The examples in this guide use Prometheus as the metrics provider.
+
+3. Complete the wizard:
+
+   The parameters you need to provide depend on the metrics provider you choose. For more information, see the {{< linkWithTitle "canary-analysis/integrate-metrics-provider.md" >}} guide.
+
+   The following fields are for a Prometheus integration:
+
+   - **Type**: (Required) Your metrics provider. This example uses Prometheus. The form options change based on your provider.
+   - **Name**: (Required) A descriptive name for your metrics provider, such as the environment it monitors. You use this name in places such as your deploy file when you want to configure canary analysis as part of your deployment strategy.
+   - **Base URL**: (Required) The base URL for your Prometheus instance. If Prometheus runs in the same cluster as the RNA and is exposed using HTTP on port 9090 through a service named `prometheus` in the namespace `prometheus`, then use `http://prometheus.prometheus:9090`. (This can be a private DNS only if the RNA is installed in the same cluster as the Prometheus instance.)
+   - **Remote Network Agent**: (Optional) The RNA that is installed in the Prometheus cluster if the cluster is not publicly accessible. Select the identifier for the RNA from the dropdown.
+   - **Authentication Type**: (Required) Select **None**, **Username/Password**, or **Bearer Token**.
+
+      - If you selected **Username/Password**: Fill in the username for accessing Prometheus and select the password secret.
+      - If you selected **Bearer Token**: Select the token secret from the drop-down list.
+
+## Perform a retrospective analysis
+
+Retrospective analysis is the starting point to creating queries so that you can perform canary analysis on your deployments. The UI gives you a structured way to create a query and test it against previous deployments. When ready, you can export it so that you can add the query to your deploy file easily.
+
+1. In the **Configuration UI**, go to [**Canary Analysis > Retrospective Analysis**](https://console.cloud.armory.io/configuration/metric-source-integrations/).
+2. Select the metric provider you just configured.
+3. Select a time range that includes when you deployed your app.
+4. Add a **Query Template**. Use the following example:
+
+   - **Name**: avgCPUUsage
+   - **Upper Limit**: The upper limit for the query. If the results exceed this value, the deployment is considered to be a failure. Set this to `10000`.
+   - **Lower Limit**: The lower limit for the query. If the results fall below this value, the deployment is considered to be a failure. Set this to `0`.
+   - **Query Template**:
+
+      ```
+      avg(avg_over_time(container_cpu_system_seconds_total{job="kubelet"}[{{armory.promQlStepInterval}}]) * on (pod) group_left (annotation_app)
+      sum(kube_pod_annotations{job="kube-state-metrics",annotation_deploy_armory_io_replica_set_name="{{armory.replicaSetName}}"}) by (annotation_app, pod)) by (annotation_app)
+      ```
+
+      - **The query must return a single result**. Automated canary analysis does not support queries that return multiple values. See [Query template requirements]({{< ref "canary-analysis-query#query-template-requirements" >}}) for restrictions and provider examples.
+      - The query contains variables that are automatically injected during canary analysis, but you must manually provide some of them during retrospective analysis.
+        - Time related variables like `armory.promqlStepInterval` are automatically substituted by Armory CD-as-a-Service. For a full list, see the {{< linkWithTitle "reference/context-variables.md" >}} guide.
+        - `armory.replicaSetName` needs to be set to the name of the ReplicaSet that Armory CD-as-a-Service created for this app version. It's used to differentiate between the current and next version of the app. Do this in the next step where you add key/value pairs.
+
+5. Add **Key Value (KV) Pair** for the **Context**. The key value pairs for your  For the sample query, you need to add the following key value Pair:
+
+  - **Key**: `replicaSetName`
+
+    **Value**: The name of the ReplicaSet that was created when you deployed the app in *Get Started with the CLI to Deploy Apps* guide.
+
+6. Run the analysis. If the results fall within the upper and lower limits you set, the deployment is considered a success.
+
+### Export and add a query to your deploy file
+
+The Retrospective Analysis can take the query you provide and generate the YAML equivalent that you can use it in your deploy file.
+
+1. From the analysis screen, select **Go back to Analysis Configuration**.
+2. Click **Export Queries for Armory Deployments**. This creates the YAML block for the `analysis` portion of a deploy file.
+3. Insert the YAML block into your deploy file at the bottom. For example:
+
+   ```yaml
+   analysis:
+     queries:
+      - name: avgCPUUsage
+        upperLimit: 10000
+        lowerLimit: 0
+        queryTemplate: >-
+          avg (avg_over_time(container_cpu_system_seconds_total{job="kubelet"}[{{armory.promQlStepInterval}}]) * on (pod)  group_left (annotation_app)
+          sum(kube_pod_annotations{job="kube-state-metrics",annotation_deploy_armory_io_replica_set_name="{{armory.replicaSetName}}"})
+          by (annotation_app, pod)) by (annotation_app)
+   ```
+
+For a detailed explanation of these fields, see the [Deployment File Reference]({{< ref "reference/deployment/config-file/analysis.md" >}})
+
+The `avgCPUUsage` query is now available for you to use in the `steps` block of your deploy file to perform canary analysis.
+
+## Add canary analysis to your deployment
+
+Armory CD-as-a-Service supports manual and automated canary analysis. Manual canary analysis allows you to review the canary results until you have confidence that your queries are making good decisions around service health.
+
+Adding canary analysis to your deployment involves updating your deploy file to include the following:
+
+- An `analysis` block that describes what queries to use and how they are run. The YAML for the queries is what you can export from the UI. You did this in [Export and add a query to your deploy file](#export-and-add-a-query-to-your-deploy-file).
+- Steps in your `strategy` block that perform canary analysis and define how it behaves.
+
+1. In your deploy file, go to the `strategies` section.
+2. Create a new strategy named `canary-deploy-strat` like the following:
+
+   ```yaml
+   strategies:
+    canary-deploy-strat
+      canary:
+        steps:
+          - setWeight:
+              weight: 50
+          - analysis:
+              interval: 10
+              units: seconds
+              numberOfJudgmentRuns: 3
+              rollBackMode: manual
+              rollForwardMode: manual
+              queries: # The queries to run
+                - avgCPUUsage
+          - setWeight:
+              weight: 75
+          - analysis:
+              interval: 10
+              units: seconds
+              numberOfJudgmentRuns: 3
+              rollBackMode: manual
+              rollForwardMode: manual
+              queries:
+                - avgCPUUsage
+   ```
+
+   For a detailed explanation of these fields, see the [Deployment File Reference]({{< ref "reference/deployment/config-file//strategies" >}})
+
+   This strategy deploys the app to 50% of the cluster and then performs a canary analysis with the following characteristics:
+
+   - The interval for each run of the query is 10 seconds.
+   - The number of runs of the query is 3.
+   - Rolling a deployment back or forward is done manually using the Deployments UI.
+   - It uses the query `containerCPUSeconds`.
+
+   The strategy then deploys the app to 75% of the cluster and then performs a canary analysis. After the roll forward is approved, Armory CD-as-a-Service deploys the app to 100% of the cluster.
+
+3. Change the value of  `targets.<targetName>.strategy` for one or more of your deployment targets to `canary-deploy-strat`.
+
+   ```yaml
+   ...
+   targets:
+     <targetName>:
+       account: <agentIdentifier>
+       namespace: <namespace>
+       strategy: canary-deploy-strat
+    ...
+    ```
+4. Save the file
+
+## Redeploy your app
+
+Make a change to your app, such as the number of replicas, and redeploy it with the CLI:
+
+```bash
+armory deploy start  -f <your-deploy-file>.yaml
+```
+
+Monitor the progress and approve the canary steps in the UI.
+
+### Go from manual to automated
+
+Once you have confidence in your queries, switching from manual approvals of canary steps to automatic approvals involves updating the `analysis` steps in your strategy. You can either comment out the `rollBackMode` and `rollForwardMode` fields or set them to `automatic`. Subsequent deployments using the updated deploy file will progress the deployment automatically if the canary analysis steps pass.
+
+## {{% heading "nextSteps" %}}
+
+* {{< linkWithTitle "canary-analysis/create-canary-queries.md" >}}
+* {{< linkWithTitle "reference/canary-analysis-query.md" >}}


### PR DESCRIPTION
Improve documentation on how to use canary strategy, and how canary strategy works under the hood. 
Resolves Jira: [CDAAS-2505]

Deploy preview https://deploy-preview-47--cdaas-docs.netlify.app/deployment/strategies/canary/

[CDAAS-2505]: https://armory.atlassian.net/browse/CDAAS-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ