### PR TITLE
docs(chore): change code highlight style

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ pygmentsUseClasses = false
 pygmentsUseClassic = false
 #pygmentsOptions = "linenos=table"
 # See https://help.farbox.com/pygments.html
-pygmentsStyle = "tango"
+pygmentsStyle = "dracula"
 
 # Google Analytics configuration
 # https://gohugo.io/templates/internal/#configure-google-analytics
@@ -40,7 +40,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
       unsafe = true
   [markup.highlight]
     # See a complete list of available styles at https://xyproto.github.io/splash/docs/all.html
-    style = "tango"
+    style = "dracula"
     # these are defaults https://gohugo.io/getting-started/configuration-markup/#highlight
     anchorLineNos = false
     codeFences = true

--- a/content/en/scratchpad.md
+++ b/content/en/scratchpad.md
@@ -1,0 +1,55 @@
+---
+title: Scratchpad
+weight: 999
+draft: true
+---
+
+## codeblock in tabpane
+
+{{< include "cli/install-cli-tabpane.md" >}}
+
+## bash
+
+```bash
+kubectl create ns armory-rna; 
+kubectl --namespace armory-rna create secret generic rna-client-credentials \
+--type=string \
+--from-literal=client-secret="<client-secret>" \
+--from-literal=client-id="<client-id>";
+kubectl apply -f "https://api.cloud.armory.io/kubernetes/agent/manifest?agentIdentifier=sample-cluster&namespace=armory-rna"
+```
+
+## yaml
+
+yaml with lines highlighted
+
+
+{{< highlight yaml "linenos=table, hl_lines=5 10 22-27" >}}
+version: v1
+kind: kubernetes
+application: potato-facts
+targets:
+  staging:
+    account: my-cdaas-cluster
+    namespace: potato-facts-staging
+    strategy: rolling
+  prod:
+    account: my-cdaas-cluster
+    namespace: potato-facts-prod
+    strategy: rolling
+    constraints:
+      dependsOn: ["staging"]
+manifests:
+  - path: manifests/potato-facts-v1.yaml
+  - path: manifests/potato-facts-service.yaml
+  - path: manifests/staging-namespace.yaml
+    targets: ["staging"]
+  - path: manifests/prod-namespace.yaml
+    targets: ["prod"]
+strategies:
+  rolling:
+    canary:
+      steps:
+        - setWeight:
+            weight: 100
+{{< /highlight >}}

--- a/content/en/tutorials/rbac.md
+++ b/content/en/tutorials/rbac.md
@@ -33,10 +33,10 @@ In this tutorial, you learn how to:
 
 * You have installed `kubectl` and have access to a Kubernetes cluster
 * You have [set up your Armory CD-as-a-Service account]({{< ref "get-started" >}}).
-* You have [installed the `armory` CLI]({{< ref "setup/cli" >}}).
+* You have [installed the `armory` CLI]({{< ref "cli" >}}).
 * You have installed [Helm](https://helm.sh/docs/intro/install/).
 * You have a GitHub account so you can fork the sample project.
-* You have read the {{< linkWithTitle "iam/_index.md.md" >}} content.
+* You have read the {{< linkWithTitle "iam/overview.md" >}} content.
 * You have completed the  {{< linkWithTitle "tutorials/deploy-sample-app.md" >}}.
 
 ## Fork and clone the repo

--- a/content/en/tutorials/tutorial-blue-green.md
+++ b/content/en/tutorials/tutorial-blue-green.md
@@ -29,7 +29,7 @@ A blue/green strategy shifts traffic from the running version of your software t
 
 ## Install the CLI
 
-{{< include "install-cli.md" >}}
+{{< include "cli/install-cli-tabpane.md" >}}
 
 add windows
 


### PR DESCRIPTION
"tango" doesn't work when code block is in a tabpane - code block background is the same as the tab background. 

Ocelots team concurred with my dracula style choice. https://cloud-armory.slack.com/archives/C04D395NBC7/p1690926841327019


