### PR TITLE
docs(infra): Update sitemap generation in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,7 +28,8 @@ package = "@netlify/plugin-sitemap"
     './public/includes/',
     './public/categories/',
     './public/tags/',
-    './public/favicons/'
+    './public/favicons/',
+    './public/404/'
   ]
   # set baseURL because we aren't configuring a custom domain in Netlify
   # Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like http://example.com/en/ will results in http://example.com/

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,7 +29,7 @@ package = "@netlify/plugin-sitemap"
     './public/categories/',
     './public/tags/',
     './public/favicons/',
-    './public/404/'
+    './public/404.html'
   ]
   # set baseURL because we aren't configuring a custom domain in Netlify
   # Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like http://example.com/en/ will results in http://example.com/

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,10 +24,16 @@ package = "@netlify/plugin-sitemap"
 
   [plugins.inputs]
   buildDir = "public"
+  exclude =[
+    './public/includes/',
+    './public/categories/',
+    './public/tags/',
+    './public/favicons/'
+  ]
   # set baseURL because we aren't configuring a custom domain in Netlify
   # Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like http://example.com/en/ will results in http://example.com/
   # https://github.com/netlify-labs/netlify-plugin-sitemap
-  baseUrl = "https://developer.armory.io"
+  baseUrl = "https://developer.armory.io/docs/"
   
   # append missing trailing slash to prettyURL
   trailingSlash = true


### PR DESCRIPTION
Update baseURL to include `/docs`
Exclude non-content directories

Google Console is still not indexing the docs portion of the site, so hopefully this new sitemap will fix that problem

![image](https://github.com/armory/docs-cdaas/assets/26799583/cc3ccbc9-8c38-49eb-89d8-9442a87c29df)

