### PR TITLE
docs(chore): Duplicate preview link page

### DIFF
--- a/content/en/deployment/preview-deployed-service.md
+++ b/content/en/deployment/preview-deployed-service.md
@@ -1,0 +1,8 @@
+---
+title: Preview a Deployed Service
+manualLinkRelRef: "reference/deployment/config-preview-link.md"
+exclude_search: true
+weight: 10
+description: >
+  Preview a deployed service by configuring a temporary preview link for testing.
+---

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,6 +18,11 @@
   to = "https://armory.releases.live/?filter=eyJ0aXRsZU9yRGVzY3JpcHRpb24iOiIiLCJzY29wZSI6WyJDRC1hcy1hLVNlcnZpY2UiXSwidHlwZSI6W10sImZpZWxkcyI6W119/"
   force = true # ensure this always redirects because the  manualLink does not work for users typing in the URL
 
+[[redirects]]
+  from = "/deployment/preview-deployed-service/" # this page contains manualLinkRelRef in frontmatter
+  to = "/reference/deployment/config-preview-link/"
+  force = true # preview-deployed-service shouldn't appear in search engine results, but if it does, always redirect (same with users typing in directly)
+
 # https://github.com/netlify-labs/netlify-plugin-sitemap
 [[plugins]]
 package = "@netlify/plugin-sitemap"
@@ -29,7 +34,8 @@ package = "@netlify/plugin-sitemap"
     './public/categories/',
     './public/tags/',
     './public/favicons/',
-    './public/404.html'
+    './public/404.html',
+    './public/deployment/preview-deployed-service/'
   ]
   # set baseURL because we aren't configuring a custom domain in Netlify
   # Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like http://example.com/en/ will results in http://example.com/


### PR DESCRIPTION
Resolves Jira: [CDAAS-2799]

New left  menu item: Deployment -> Preview a Deployed Service (deployment/preview-deployed-service)
When. a user clicks the menu item, the site redirects the user to /reference/deployment/config-preview-link/.  
I used this approach instead of two pages with shared include files because the config-preview-link page already has includes, and I can't do includes in includes.
preview-deployed-service is excluded from site search

Update netlify.toml:
- Exclude preview-deployed-service from generated sitemap
- Add redirect that does a forced redirect from preview-deployed-service to config-preview-link. preview-deployed-service shouldn't show up in search engine results, but if it does, this redirect prevents a user clicking the search result and being directed to a blank page.

[CDAAS-2799]: https://armory.atlassian.net/browse/CDAAS-2799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ