### PR TITLE
docs(linkCheck): add link check disable around a code block

### DIFF
--- a/content/en/deployment/kubernetes/argo-rollouts.md
+++ b/content/en/deployment/kubernetes/argo-rollouts.md
@@ -110,6 +110,7 @@ See {{< linkWithTitle "reference/deployment/_index.md" >}} if you want to create
 
 You can use webhooks in `afterDeployment` constraints to add specific logic for Argo Rollouts to finish deploying before starting integration tests. For example:
 
+<!-- markdown-link-check-disable -->
 {{< highlight yaml "linenos=table,hl_lines=9-12 15-28" >}}
  # armoryDeployment.yaml
 version: v1
@@ -140,6 +141,7 @@ webhooks:
         "callbackURL": "{{armory.callbackUri}}/callback"
         }
 {{< /highlight >}}
+<!-- markdown-link-check-enable-->
 
 This example employs [cmd-hook](https://hub.docker.com/r/demoimages/cmd-hook), which is an open source service deployed in the cluster to execute `kubectl` commands. CD-as-a-Service employs RNA to execute `kubectl` commands for monitoring the state of rollout objects. You can view the source code for `cmd-hook` in the [public repository](https://github.com/stephenatwell/cmdHook).
 


### PR DESCRIPTION
... to stop the link check fail

`http://cmd-hook.default:8081/cmd` in the code block is causing the error
